### PR TITLE
Update the safe SVG plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "1.9.4",
+		"darylldoyle/safe-svg": "1.9.6",
 		"humanmade/tachyon-plugin": "0.10.2",
 		"humanmade/smart-media": "0.2.1",
 		"humanmade/gaussholder": "1.1.3",


### PR DESCRIPTION
Updates to 1.9.6 to patch a potential XSS vulnerability.