### PR TITLE
Backport #46 to v1-branch: Check tachyon is enabled before loading smart media

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,8 @@ function load_plugins() {
 		require_once $vendor_dir . '/humanmade/tachyon-plugin/tachyon.php';
 	}
 
-	if ( $config['smart-media'] ) {
+	// Smart Media requires Tachyon to work.
+	if ( $config['tachyon'] && $config['smart-media'] ) {
 		require_once $vendor_dir . '/humanmade/smart-media/plugin.php';
 		remove_filter( 'intermediate_image_sizes_advanced', 'HM\\Media\\Cropper\\prevent_thumbnail_generation' );
 	}


### PR DESCRIPTION
Backporting fix for tachyon not being enabled.