### PR TITLE
Update smart media to 0.1.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=7.1",
 		"humanmade/tachyon-plugin": "0.10.2",
-		"humanmade/smart-media": "0.1.14",
+		"humanmade/smart-media": "0.1.16",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "0.1.6"
 	},


### PR DESCRIPTION
Brings smart media 0.1.x up to date. 2 Bug fixes:

- Don't hide image edit link if cropping UI not in effect
- Allow special chars in image size names