### PR TITLE
Update smart media to 0.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "1.9.6",
 		"humanmade/tachyon-plugin": "0.10.2",
-		"humanmade/smart-media": "0.2.3",
+		"humanmade/smart-media": "0.2.4",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "0.1.6"
 	},


### PR DESCRIPTION
Fixes a potential fatal if attachment metadata can't be found - this only occurs if the attachment ID doesn't match an existing post on the site.