### PR TITLE
Remove query modification filter in Rekognition

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -19,7 +19,9 @@ function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugins', 1 );
 
 	// Remove AWS_Rekognition filter for performance purposes, as ElasticSearch is used instead.
-	remove_filter( 'posts_clauses', 'HM\\AWS_Rekognition\\filter_query_attachment_keywords' );
+	add_action( 'plugins_loaded', function () {
+		remove_filter( 'posts_clauses', 'HM\\AWS_Rekognition\\filter_query_attachment_keywords' );
+	}, 11 );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,6 +17,9 @@ use function HM\AWS_Rekognition\get_attachment_labels;
  */
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugins', 1 );
+
+	// Remove AWS_Rekognition filter for performance purposes, as ElasticSearch is used instead.
+	remove_filter( 'posts_clauses', 'HM\\AWS_Rekognition\\filter_query_attachment_keywords' );
 }
 
 /**


### PR DESCRIPTION
Fixes #59 

I'm a bit unsure how to test this. I've tried the following:

1. Enabled `AWS_Rekognition` by adding the following to the `composer.json`
```
"altis": {
      "modules": {
        "media": {
          "rekognition": true
        }
...
```
2. Even with that config and nothing yet being removed, when I inspected `global $wp_filter['posts_clauses']` I didn't see anything there.

Perhaps I enabled the module incorrectly?