### PR TITLE
Updates tachyon to 0.11.0 and smart media to 0.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
 	"require": {
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "1.9.6",
-		"humanmade/tachyon-plugin": "0.10.2",
-		"humanmade/smart-media": "0.2.4",
+		"humanmade/tachyon-plugin": "0.11.0",
+		"humanmade/smart-media": "0.2.5",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "0.1.6"
 	},


### PR DESCRIPTION
Fixes a series of bugs in both plugins, fatal errors on REST API requests for attachment IDs not found on the site and inability to select an image from the cropping UI image edit popup.