### PR TITLE
Update tachyon plugin to 0.11.1 and track patch version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "1.9.6",
-		"humanmade/tachyon-plugin": "0.11.0",
+		"humanmade/tachyon-plugin": "~0.11.1",
 		"humanmade/smart-media": "^0.2.7",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "0.1.6"


### PR DESCRIPTION
This is required for the latest version of smart media to work.