### PR TITLE
Update Rekognition to 0.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"humanmade/tachyon-plugin": "~0.11.1",
 		"humanmade/smart-media": "^0.2.7",
 		"humanmade/gaussholder": "1.1.3",
-		"humanmade/aws-rekognition": "0.1.6"
+		"humanmade/aws-rekognition": "~0.1.7"
 	},
 	"autoload": {
 		"files": [


### PR DESCRIPTION
Also tracks the patch release.

Fixes several bugs:

- Only run on images
- Don't override all fields on image edit screen
- Improve error display