### PR TITLE
Update smart media to 0.2.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "1.9.9",
 		"humanmade/tachyon-plugin": "~0.11.1",
-		"humanmade/smart-media": "^0.2.7",
+		"humanmade/smart-media": "~0.2.20",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "~0.1.7"
 	},


### PR DESCRIPTION
We want to ensure this much more stable version is in use on v3 and v4.