### PR TITLE
Add `$content_width` documentation

### DIFF
--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -16,7 +16,19 @@ They have default dimensions, but you can override these either with code or in 
 
 If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal. This global is intended to be used as an upper limit on the width of images based on your theme's design.
 
-To make sure these sizes don't come into conflict, set the `$content_width` global to a large enough size that the admin setting won't override it.
+For example, if your theme had a content area that was 1000 pixels wide, you might set the `$content_width` global in your theme like this:
+
+```php
+add_action( 'after_setup_theme', function () {
+	global $content_width;
+
+	if ( ! isset( $content_width ) ) {
+		$content_width = 1000;
+	}
+} );
+```
+
+With this setting, in the admin, even if the Large image size on the Settings > Media page is greater than 1000, the _actual_ image size will never be larger than 1000, and this will be reflected in the media modal.
 
 The `$content_width` variable has been a recommended part of a theme's `functions.php` file since WordPress 2.6.
 

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -12,7 +12,7 @@ They have default dimensions, but you can override these either with code or in 
 
 ![Media Settings](./assets/media-settings.png)
 
-### `content_width`
+### Content Width
 
 If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal.
 

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -22,9 +22,7 @@ For example, if your theme had a content area that was 1000 pixels wide, you mig
 add_action( 'after_setup_theme', function () {
 	global $content_width;
 
-	if ( ! isset( $content_width ) ) {
-		$content_width = 1000;
-	}
+	$content_width = 1000;
 } );
 ```
 

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -14,7 +14,7 @@ They have default dimensions, but you can override these either with code or in 
 
 ### Content Width
 
-If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal.
+If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal. This global is intended to be used as an upper limit on the width of images based on your theme's design.
 
 To make sure these sizes don't come into conflict, set the `$content_width` global to a large enough size that the admin setting won't override it.
 

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -14,9 +14,11 @@ They have default dimensions, but you can override these either with code or in 
 
 ### `content_width`
 
-If your theme defines a content width either via the `$content_width` or `$GLOBALS['content_width]` globals, this size will _override_ the size defined on the Settings > Media page and the Large size may appear to be the "wrong" size (based on the size defined in the _global_ rather than the size in the admin) in the media modal.
+If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal.
 
-To make sure these sizes align, set the `content_width` in the global to a large enough size that the admin setting won't override it, or don't define the `$content_width` global in your theme.
+To make sure these sizes don't come into conflict, set the `$content_width` global to a large enough size that the admin setting won't override it.
+
+The `$content_width` variable has been a recommended part of a theme's `functions.php` file since WordPress 2.6.
 
 ### Custom Image Sizes
 

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -12,6 +12,14 @@ They have default dimensions, but you can override these either with code or in 
 
 ![Media Settings](./assets/media-settings.png)
 
+### `content_width`
+
+If your theme defines a content width either via the `$content_width` or `$GLOBALS['content_width]` globals, this size will _override_ the size defined on the Settings > Media page and the Large size may appear to be the "wrong" size (based on the size defined in the _global_ rather than the size in the admin) in the media modal.
+
+To make sure these sizes align, set the `content_width` in the global to a large enough size that the admin setting won't override it, or don't define the `$content_width` global in your theme.
+
+### Custom Image Sizes
+
 A lot of times, you'll find that you need custom image sizes for different contexts, depending on your theme's design.
 
 You can define custom image sizes with the `add_image_size()` function.


### PR DESCRIPTION
Adds documentation about `content_width` overriding the Large media sizes set in the admin.

I tried to make this as accurate as possible without explicitly saying "don't use `$content_width`" since it's "required" since WP 2.6. 

Fixes #113 