### PR TITLE
Add lazy loading iframe docs

### DIFF
--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -50,7 +50,7 @@ Note: changing the radius requires regenerating the placeholder data. Run `wp ga
 
 Inline frames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `<iframe>` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. Embedded `<iframe>` tags provided via oEmbed in content run through `the_content`, `the_excerpt` or `widget_text_content` filters will have the `loading="lazy"` attribute added by default where the web service has provided a `width` and `height` attribute.
 
-You can customize whether and how iFrames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable lazy-loading of iFrames from post content entirely, you could use the following code:
+You can customize whether and how inline frames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable lazy-loading of inline frames from post content entirely, you could use the following code:
 
 ```php
 add_filter( 'wp_lazy_loading_enabled', function( $default, $tag_name, $context ) {

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -46,7 +46,7 @@ Gaussholder includes a CLI command to help you tune the radius: pick a represent
 
 Note: changing the radius requires regenerating the placeholder data. Run `wp gaussholder process-all --regenerate` after changing radii or adding new sizes.
 
-## Lazy Loading iFrames
+## Lazy Loading Inline Frames
 
 Inline frames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `<iframe>` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. Embedded `<iframe>` tags provided via oEmbed in content run through `the_content`, `the_excerpt` or `widget_text_content` filters will have the `loading="lazy"` attribute added by default where the web service has provided a `width` and `height` attribute.
 

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -45,3 +45,31 @@ The radius needs to be tuned to each size individually. Facebook uses about 200 
 Gaussholder includes a CLI command to help you tune the radius: pick a representative attachment or image file and use `wp gaussholder check-size <id_or_image> <radius>`. Adjust the radius until you get to roughly 200B, then check against other attachments to ensure they're in the ballpark.
 
 Note: changing the radius requires regenerating the placeholder data. Run `wp gaussholder process-all --regenerate` after changing radii or adding new sizes.
+
+## Lazy Loading iFrames
+
+iFrames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `iframe` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. oEmbeded iframe content within `the_content`, `the_excerpt` and `widget_text_content` will have the `loading="lazy"` tag added by default where the web service has provided a `width` and `height` attribute.
+
+You can customize whether and how iFrames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable lazy-loading of iFrames from post content entirely, you could use the following code:
+
+```php
+add_filter( 'wp_lazy_loading_enabled', function( $default, $tag_name, $context ) {
+	if ( $tag_name === 'iframe' && $context === 'the_content'  ) {
+		return false;
+	}
+
+	return $default;
+}, 10, 3 );
+```
+
+You can also use the `wp_iframe_tag_add_loading_attr` filter to customize a specific iFrame tag. For example, if you wanted to disable lazy-loading on iFrames from a specific provider, like YouTube, you could use the following code:
+
+```php
+add_filter( 'wp_iframe_tag_add_loading_attr', function( $value, $iframe, $context ) {
+	if ( $context === 'the_content' && false !== strpos( $iframe, 'youtube.com' ) ) {
+		return false;
+	}
+
+	return $value;
+}, 10, 3 );
+```

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -48,7 +48,7 @@ Note: changing the radius requires regenerating the placeholder data. Run `wp ga
 
 ## Lazy Loading iFrames
 
-iFrames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `iframe` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. oEmbeded iframe content within `the_content`, `the_excerpt` and `widget_text_content` will have the `loading="lazy"` tag added by default where the web service has provided a `width` and `height` attribute.
+Inline frames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `<iframe>` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. Embedded `<iframe>` tags provided via oEmbed in content run through `the_content`, `the_excerpt` or `widget_text_content` filters will have the `loading="lazy"` attribute added by default where the web service has provided a `width` and `height` attribute.
 
 You can customize whether and how iFrames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable lazy-loading of iFrames from post content entirely, you could use the following code:
 

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -62,7 +62,7 @@ add_filter( 'wp_lazy_loading_enabled', function( $default, $tag_name, $context )
 }, 10, 3 );
 ```
 
-You can also use the `wp_iframe_tag_add_loading_attr` filter to customize a specific iFrame tag. For example, if you wanted to disable lazy-loading on iFrames from a specific provider, like YouTube, you could use the following code:
+You can also use the `wp_iframe_tag_add_loading_attr` filter to customize a specific `<iframe>` tag. For example, if you wanted to disable lazy-loading on inline frames from a specific provider, like YouTube, you could use the following code:
 
 ```php
 add_filter( 'wp_iframe_tag_add_loading_attr', function( $value, $iframe, $context ) {


### PR DESCRIPTION
Closes humanmade/altis-documentation#201

Adds some docs for iframe lazy loading into the lazy loading documentation within the Media module.