### PR TITLE
Only load AMF when we have a provider

### DIFF
--- a/docs/asset-manager-framework.md
+++ b/docs/asset-manager-framework.md
@@ -6,7 +6,19 @@ It handles the necessary integration with WordPress (Ajax endpoints and Backbone
 
 The intention is that media provided by any external source will become a seamless part of your site's media library.
 
-AMF is included and loaded by Altis of the box.
+## Loading AMF
+
+AMF is loaded automatically when using the Global Media Library feature, however if you would like to use the framework without that feature you can conditionally load it in using the function `Altis\Media\load_amf()`:
+
+```php
+add_action( 'plugins_loaded', function () {
+    Altis\Media\load_amf();
+}, 9 );
+
+add_filter( 'amf/provider', function () {
+    return new CustomProvider();
+} );
+```
 
 ## Implementation
 

--- a/docs/asset-manager-framework.md
+++ b/docs/asset-manager-framework.md
@@ -8,7 +8,7 @@ The intention is that media provided by any external source will become a seamle
 
 ## Loading AMF
 
-AMF is loaded automatically when using the Global Media Library feature, however if you would like to use the framework without that feature you can conditionally load it in using the function `Altis\Media\load_amf()`:
+AMF is loaded automatically when using the Global Media Library feature, however if you would like to use the framework without the global media library you can manually load it using the function `Altis\Media\load_amf()`:
 
 ```php
 add_action( 'plugins_loaded', function () {

--- a/inc/global_assets/namespace.php
+++ b/inc/global_assets/namespace.php
@@ -9,6 +9,7 @@ namespace Altis\Media\Global_Assets;
 
 use Altis;
 use Altis\Global_Content;
+use Altis\Media;
 
 /**
  * Setup global media hooks.
@@ -18,12 +19,12 @@ use Altis\Global_Content;
 function bootstrap() {
 	$config = Altis\get_config()['modules']['media'];
 
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_amf', 5 );
-
-	// Load WP AMF and configure global site.
 	if ( empty( $config['global-media-library'] ) ) {
 		return;
 	}
+
+	// Load WP AMF and configure global site.
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_amf_wp', 5 );
 
 	// Bail if a site URL has been provided, assume it's external.
 	if ( is_string( $config['global-media-library'] ) ) {
@@ -37,26 +38,25 @@ function bootstrap() {
 }
 
 /**
- * Load Asset Mnnager Framework.
+ * Load Asset Manager Framework for WordPress.
  *
  * @return void
  */
-function load_amf() {
-	$config = Altis\get_config()['modules']['media'];
+function load_amf_wp() {
+	// Wait until post installation.
+	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+		return;
+	}
 
 	// Load Asset Manager Framework.
-	require_once Altis\ROOT_DIR . '/vendor/humanmade/asset-manager-framework/plugin.php';
+	Media\load_amf();
 
-	// Load WP AMF and configure global site.
-	if ( $config['global-media-library'] ) {
-		require_once Altis\ROOT_DIR . '/vendor/humanmade/amf-wordpress/plugin.php';
-	}
+	// Load AMF WP.
+	require_once Altis\ROOT_DIR . '/vendor/humanmade/amf-wordpress/plugin.php';
 }
 
 /**
  * Create the Global Media Library site.
- *
- * @throws Exception If media site cannot be created.
  */
 function configure_site() {
 	// Wait until post installation.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -199,3 +199,11 @@ function add_rekognition_keywords_to_autosuggest( array $fields ) : array {
 function load_safe_svg() {
 	require_once Altis\ROOT_DIR . '/vendor/darylldoyle/safe-svg/safe-svg.php';
 }
+
+/**
+ * Load Asset Mnnager Framework.
+ */
+function load_amf() {
+	// Load Asset Manager Framework.
+	require_once Altis\ROOT_DIR . '/vendor/humanmade/asset-manager-framework/plugin.php';
+}


### PR DESCRIPTION
Loading AMF without a provider results in the blank provider being used and returning no results. This updates the loading logic and updates the docs to describe manually loading AMF.