### PR TITLE
Skip AMF attachments in Smart Media

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "1.9.9",
 		"humanmade/tachyon-plugin": "~0.11.1",
-		"humanmade/smart-media": "~0.3.0",
+		"humanmade/smart-media": "~0.4.0",
 		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "~0.1.7",
 		"humanmade/rename-images-command": "^0.1.0",

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -50,6 +50,8 @@ function load_plugins() {
 				return $modifiers;
 			}, 9 );
 		}
+		// Avoid processing external attachments.
+		add_filter( 'hm.smart-media.skip-attachment', __NAMESPACE__ . '\\maybe_skip_smart_media', 10, 2 );
 		require_once $vendor_dir . '/humanmade/smart-media/plugin.php';
 	}
 
@@ -206,4 +208,19 @@ function load_safe_svg() {
 function load_amf() {
 	// Load Asset Manager Framework.
 	require_once Altis\ROOT_DIR . '/vendor/humanmade/asset-manager-framework/plugin.php';
+}
+
+/**
+ * Check whether we should skip Smart Media processing for this image.
+ *
+ * @param boolean $skip Set to true to skip processing.
+ * @param integer $attachment_id The attachment ID to check.
+ * @return boolean
+ */
+function maybe_skip_smart_media( bool $skip, int $attachment_id ) : bool {
+	if ( ! empty( get_post_meta( $attachment_id, 'amf_provider', true ) ) ) {
+		return true;
+	}
+
+	return $skip;
 }


### PR DESCRIPTION
Prevents showing the edit mode for any known external media.