### PR TITLE
Add link to global media library from upload

### DIFF
--- a/docs/global-media-library.md
+++ b/docs/global-media-library.md
@@ -35,3 +35,36 @@ Alternatively the media library config option can be set to any WordPress site U
 	}
 }
 ```
+
+## Disallowing Local Media
+
+Along with the Global Media Library you can optionally switch off each site's Local Media Library to force using the global library.
+
+To do so you can add the following config:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"modules": {
+				"media": {
+					"local-media-library": false
+				}
+			}
+		}
+	}
+}
+```
+
+Alternatively you can also use the `amf/allow_local_media` filter to conditionally control which sites can use Local Media and which cannot.
+
+```php
+add_filter( 'amf/allow_local_media', function () : bool {
+	// Local for a custom site meta entry.
+	if ( get_site_meta( get_current_site_id(), 'allow_local_media' ) ) {
+		return true;
+	}
+
+	return false;
+} );
+```

--- a/inc/global_assets/namespace.php
+++ b/inc/global_assets/namespace.php
@@ -19,6 +19,11 @@ use Altis\Media;
 function bootstrap() {
 	$config = Altis\get_config()['modules']['media'];
 
+	// Configure local media provider for AMF.
+	if ( empty( $config['local-media-library'] ) && ! defined( 'AMF_ALLOW_LOCAL_MEDIA' ) ) {
+		define( 'AMF_ALLOW_LOCAL_MEDIA', false );
+	}
+
 	if ( empty( $config['global-media-library'] ) ) {
 		return;
 	}
@@ -38,6 +43,9 @@ function bootstrap() {
 
 	// Configure the WP provider name.
 	add_filter( 'amf/wordpress/provider_name', __NAMESPACE__ . '\\set_global_site_provider_name' );
+
+	// Add link to global content site.
+	add_action( 'pre-plupload-upload-ui', __NAMESPACE__ . '\\pre_upload_global_site_link' );
 }
 
 /**
@@ -123,4 +131,19 @@ function allow_media_pages( array $pages ) : array {
 	$pages[] = 'upload.php';
 	$pages[] = 'media.php';
 	return $pages;
+}
+
+/**
+ * Add a link to Global Media in the upload UI.
+ */
+function pre_upload_global_site_link() : void {
+	if ( Global_Content\is_global_site() ) {
+		return;
+	}
+
+	printf(
+		'<p><a class="components-button is-link" href="%s">%s</a></p>',
+		get_admin_url( Global_Content\get_site_id(), '/upload.php' ),
+		esc_html__( 'Switch to Global Media Library', 'altis' )
+	);
 }

--- a/load.php
+++ b/load.php
@@ -25,6 +25,7 @@ add_action( 'altis.modules.init', function () {
 			'text' => false,
 		],
 		'global-media-library' => false,
+		'local-media-library' => true,
 	];
 	Altis\register_module( 'media', __DIR__, 'Media', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );


### PR DESCRIPTION
Fixes #123

Also dependent on a fix to AMF in a separate PR.

Media modal:
<img width="999" alt="Screenshot 2021-06-14 at 18 58 18" src="https://user-images.githubusercontent.com/23417/121937414-936f1b80-cd42-11eb-937a-1dda49486b64.png">

Media admin screens:
<img width="332" alt="Screenshot 2021-06-14 at 18 57 53" src="https://user-images.githubusercontent.com/23417/121937466-9cf88380-cd42-11eb-9c3b-fca050183bae.png">

Accessing the global site without permissions:
<img width="796" alt="Screenshot 2021-06-14 at 18 56 43" src="https://user-images.githubusercontent.com/23417/121937476-a124a100-cd42-11eb-86a0-64bc16ebbed4.png">
