### PR TITLE
Update AMF post meta key for skipping media edit UI

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -243,7 +243,7 @@ function load_amf() {
  * @return boolean
  */
 function maybe_skip_smart_media( bool $skip, int $attachment_id ) : bool {
-	if ( ! empty( get_post_meta( $attachment_id, 'amf_provider', true ) ) ) {
+	if ( ! empty( get_post_meta( $attachment_id, '_amf_provider', true ) ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
Forgot to update this when switching to an underscore prefixed provider meta data.