### PR TITLE
Revert "Update darylldoyle/safe-svg requirement from 1.9.9 to 1.9.10"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "1.9.10",
+		"darylldoyle/safe-svg": "1.9.9",
 		"humanmade/tachyon-plugin": "~0.11.5",
 		"humanmade/smart-media": "~0.4.3",
 		"humanmade/gaussholder": "1.1.3",


### PR DESCRIPTION
Reverts humanmade/altis-media#220

Broken, this was a breaking change released as a patch version upstream.