### PR TITLE
Update Safe SVG to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "1.9.9",
+		"darylldoyle/safe-svg": "2.0.1",
 		"humanmade/tachyon-plugin": "~0.11.5",
 		"humanmade/smart-media": "~0.4.3",
 		"humanmade/gaussholder": "1.1.3",


### PR DESCRIPTION
Required for installing Altis with PHP 8