### PR TITLE
Allow darylldoyle/safe-svg 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "1.9.9",
+		"darylldoyle/safe-svg": "1.9.9 | 1.9.10",
 		"humanmade/tachyon-plugin": "~0.11.5",
 		"humanmade/smart-media": "~0.4.3",
 		"humanmade/gaussholder": "1.1.3",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "1.9.9 | 1.9.10",
+		"darylldoyle/safe-svg": "1.9.9 | ~2.0.1",
 		"humanmade/tachyon-plugin": "~0.11.5",
 		"humanmade/smart-media": "~0.4.3",
 		"humanmade/gaussholder": "1.1.3",


### PR DESCRIPTION
Version 2.0.1 is the minimum requirement to run with PHP 8.0. It does seem to introduce quite a few changes, hence the | syntax to not force existing users to upgrade from 1.9.9.

This is a requirement to have our v11 tests pass with PHP 8.0.