### PR TITLE
Update Smart Media for WP 6.0+ compatiblity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "2.0.3",
 		"humanmade/tachyon-plugin": "~0.11.8",
-		"humanmade/smart-media": "~0.4.6",
+		"humanmade/smart-media": "~0.5.0",
 		"humanmade/aws-rekognition": "~0.1.8",
 		"humanmade/rename-images-command": "^0.1.0",
 		"humanmade/asset-manager-framework": "^0.13.5",


### PR DESCRIPTION
The smart media image editing UI and functionality has been broken since WP 6.0 / Altis v13.

This update restores that functionality and also fixes an incompatilbity with WP 6.4 whereby cropped image sizes were not present on the frontend srcset, also the width and height attributes were derived incorrectly.

The backport is safe as a patch release here even though it's bumping the minor version because the updates are all backwards compatible with WP 6.0+/Altis v13.

See https://github.com/humanmade/smart-media/issues/219