### PR TITLE
Update AWS Rekognition plugin to 0.1.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"darylldoyle/safe-svg": "2.0.3",
 		"humanmade/tachyon-plugin": "~0.11.9",
 		"humanmade/smart-media": "~0.5.3",
-		"humanmade/aws-rekognition": "~0.1.8",
+		"humanmade/aws-rekognition": "~0.1.9",
 		"humanmade/rename-images-command": "^0.1.0",
 		"humanmade/asset-manager-framework": "^0.13.5",
 		"humanmade/amf-wordpress": "^0.3.0"


### PR DESCRIPTION
Includes a hotfix for attachment data polling

https://github.com/humanmade/aws-rekognition/releases/tag/0.1.9