### PR TITLE
Reformat docs files after linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@f1fd9a5
+  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112a
     mode: deep_merge_append
 
 # Add your custom config below, which will merge with the default module config from the section above.

--- a/docs/asset-manager-framework.md
+++ b/docs/asset-manager-framework.md
@@ -1,14 +1,18 @@
 # Asset Manager Framework
 
-The Asset Manager Framework (AMF) enables using external providers such as a Digital Asset Manager (DAM), another WordPress website, or a central site within a Multisite installation. The [Global Media Library feature](./global-media-library.md) is built on top of this framework.
+The Asset Manager Framework (AMF) enables using external providers such as a Digital Asset Manager (DAM), another WordPress website,
+or a central site within a Multisite installation. The [Global Media Library feature](./global-media-library.md) is built on top of
+this framework.
 
-It handles the necessary integration with WordPress (Ajax endpoints and Backbone components) leaving you to focus on just the server-side API connection to your media source.
+It handles the necessary integration with WordPress (Ajax endpoints and Backbone components) leaving you to focus on just the
+server-side API connection to your media source.
 
 The intention is that media provided by any external source will become a seamless part of your site's media library.
 
 ## Loading AMF
 
-AMF is loaded automatically when using the Global Media Library feature, however if you would like to use the framework without the global media library you can manually load it using the function `Altis\Media\load_amf()`:
+AMF is loaded automatically when using the Global Media Library feature, however if you would like to use the framework without the
+global media library you can manually load it using the function `Altis\Media\load_amf()`:
 
 ```php
 add_action( 'plugins_loaded', function () {
@@ -23,22 +27,31 @@ There are two main aspects to the framework.
 1. Allow the media manager grid to display external items which are not attachments on the current site.
 2. Subsequently create a local attachment for an external item when it's selected for use.
 
-The design decision behind this is that allowing for external items to be browsed in the media manager is quite straight forward, but unless each item is associated with a local attachment then most of the rest of WordPress breaks when you go to use an item.
+The design decision behind this is that allowing for external items to be browsed in the media manager is quite straight forward,
+but unless each item is associated with a local attachment then most of the rest of WordPress breaks when you go to use an item.
 
-Asset Manager Framework instead allows external media items to be browsed in the media library grid, but as soon as an item is selected for use (eg. to be inserted into a post or used as a featured image), an attachment is created for the media item, and this gets returned by the media manager.
+Asset Manager Framework instead allows external media items to be browsed in the media library grid, but as soon as an item is
+selected for use (e.g. to be inserted into a post or used as a featured image), an attachment is created for the media item, and
+this gets returned by the media manager.
 
-The actual media file does not get sideloaded into WordPress - it intentionally remains at its external URL. The correct external URL gets referred to as necessary, while a local object attachment is maintained that can be referenced and queried within WordPress.
+The actual media file does not get side loaded into WordPress - it intentionally remains at its external URL. The correct external
+URL gets referred to as necessary, while a local object attachment is maintained that can be referenced and queried within
+WordPress.
 
 ## Integration
 
 There are four steps needed to integrate a media provider using the Asset Manager Framework:
 
-1. Create a provider which extends the `AssetManagerFramework\Provider` class and implements its `get_id()`, `get_name()` and `request()` methods.
-2. Process the response from the external media provider by creating an array of `AssetManagerFramework\Media` objects (or objects that extend that class) and setting values on each according to the response data.
-3. Return a new `AssetManagerFramework\MediaResponse` object. The `MediaResponse` object takes a `MediaList` (with the array of `AssetManagerFramework\Media` objects as its first parameter), the total number of items available, and the number of items requested per page.
-2. Hook into the `amf/register_providers` action to register your provider for use.
+1. Create a provider which extends the `AssetManagerFramework\Provider` class and implements its `get_id()`, `get_name()`
+   and `request()` methods.
+2. Process the response from the external media provider by creating an array of `AssetManagerFramework\Media` objects (or objects
+   that extend that class) and setting values on each according to the response data.
+3. Return a new `AssetManagerFramework\MediaResponse` object. The `MediaResponse` object takes a `MediaList` (with the array
+   of `AssetManagerFramework\Media` objects as its first parameter), the total number of items available, and the number of items
+   requested per page.
+4. Hook into the `amf/register_providers` action to register your provider for use.
 
-Here's a basic example of a provider which supplies images from unsplash.com:
+Here's a basic example of a provider which supplies images from Unsplash:
 
 ```php
 use AssetManagerFramework\Image;
@@ -63,7 +76,7 @@ class UnsplashProvider extends Provider {
      * @param array $args The WP_Query args array.
      * @return MediaResponse
      */
-	protected function request( array $args ) : MediaResponse {
+    protected function request( array $args ) : MediaResponse {
 
         $url = 'https://api.unsplash.com/photos';
 
@@ -110,17 +123,20 @@ class UnsplashProvider extends Provider {
 
 // Register the provider.
 add_action( 'amf/register_providers', function ( ProviderRegistry $provider_registry ) {
-	$provider_registry->register( new UnsplashProvider() );
+    $provider_registry->register( new UnsplashProvider() );
 } );
 ```
 
-For a more complete example using Unsplash see the [AMF Unsplash integration plugin](https://github.com/humanmade/amf-unsplash) for reference.
+For a complete example using Unsplash see the [AMF Unsplash integration plugin](https://github.com/humanmade/amf-unsplash) for
+reference.
 
-Depending on the API you are querying the way to find the total number of items available may vary, typically they are provided in query response headers.
+Depending on the API you are querying the way to find the total number of items available may vary, typically they are provided in
+query response headers.
 
 ### Dynamic Image Resizing
 
-AMF provides an interface to enable dynamic image resizing for your provider classes. The Global Media Library uses this to deliver assets via Tachyon out of the box.
+AMF provides an interface to enable dynamic image resizing for your provider classes. The Global Media Library uses this to deliver
+assets via Tachyon out of the box.
 
 To make a provider that can resize assets on the fly it needs to implement the `Resize` interface:
 
@@ -156,7 +172,8 @@ class ResizingUnsplashProvider extends UnsplashProvider implements Resize {
 
 ### Modifying Existing Providers
 
-Since you have access to each provider instance during registration via the `amf/provider` filter, you can also use it and decorate it, replace it with a subclass of a specific provider or replace it entirely:
+Since you have access to each provider instance during registration via the `amf/provider` filter, you can also use it and decorate
+it, replace it with a subclass of a specific provider or replace it entirely:
 
 ```php
 use AssetManagerFramework\Provider;
@@ -167,11 +184,12 @@ add_filter( 'amf/provider', function ( Provider $provider, string $id ) {
         return $provider;
     }
 
-	return new ResizingUnsplashProvider();
+    return new ResizingUnsplashProvider();
 }, 10, 2 );
 ```
 
-This is useful, for example, when you are using a third-party provider implementation and want to change certain behavior. Remember to use a priority later than the default for this filter, for example 20, so your code runs after the default filter.
+This is useful, for example, when you are using a third-party provider implementation and want to change certain behavior. Remember
+to use a priority later than the default for this filter, for example 20, so your code runs after the default filter.
 
 ### `AssetManagerFramework\ProviderRegistry` Class
 
@@ -191,7 +209,9 @@ Registers a new provider class.
 
 ### `AssetManagerFramework\MediaResponse( MediaList $items, int $total = 0, int $per_page = 40 )` Class
 
-The `MediaResponse` class ensures that the media library can correctly provide paginated results. You should derive the values for the total number of items available and the items requested per page from any remote requests made in your `Provider`'s `request` method.
+The `MediaResponse` class ensures that the media library can correctly provide paginated results. You should derive the values for
+the total number of items available and the items requested per page from any remote requests made in your `Provider`'s `request`
+method.
 
 **`get_items() : MediaList`**
 
@@ -204,9 +224,11 @@ Returns the total number of available items set via the constructor. Used intern
 **`get_total_pages() : int`**
 
 Returns the total number of pages available to paginate through. Used internally to set response headers.
+
 ### `AssetManagerFramework\Media` Class
 
-The `Media` object is important as it allows you easily map data from any API to data that Altis can understand and use. It is recommended to set as much data as possible given the API responses.
+The `Media` object is important as it allows you easily map data from any API to data that Altis can understand and use. It is
+recommended to set as much data as possible given the API responses.
 
 The following methods are available:
 
@@ -228,9 +250,11 @@ Sets the height of the original file in pixels.
 
 **`set_sizes( array $sizes )`**
 
-The most complex component to set the data for, the sizes array must be a particular shape and defines all the different thumbnail sizes and crops you may need. Determining this data depends a lot on how the provider returns data and how it generates resized images.
+The most complex component to set the data for, the sizes array must be a particular shape and defines all the different thumbnail
+sizes and crops you may need. Determining this data depends a lot on how the provider returns data and how it generates resized
+images.
 
-The sizes array should be a list with size names as keys and width, height, orientation and url data:
+The sizes array should be a list with size names as keys and width, height, orientation and URL data:
 
 ```php
 $sizes = [
@@ -308,7 +332,8 @@ Sets the alternative text for the media, commonly used in the `alt` attribute.
 
 **`set_description( string $description )`**
 
-Sets the description text for the media, can be used for the caption in some cases but is intended for a long description of the file.
+Sets the description text for the media, can be used for the caption in some cases but is intended for a long description of the
+file.
 
 **`set_caption( string $caption )`**
 
@@ -320,11 +345,11 @@ Sets the slug or URL safe version of the media title for use in links.
 
 **`set_date( int $date )`**
 
-A unix timestamp of when the file was created.
+A Unix timestamp of when the file was created.
 
 **`set_modified( int $modified )`**
 
-A unix timestamp of when the file was last edited.
+A Unix timestamp of when the file was last edited.
 
 **`set_file_size( int $file_size )`**
 
@@ -344,7 +369,8 @@ Adds an item of meta data rather than setting or overwriting data like `set_meta
 
 **`set_amf_meta( array $meta )`**
 
-Set additional meta data not stored in the database but for use within AMF during processing. See the hooks and filters section below.
+Set additional meta data not stored in the database but for use within AMF during processing. See the hooks and filters section
+below.
 
 **`add_amf_meta( string $key, mixed $value )`**
 
@@ -360,7 +386,8 @@ Extends the `AssetManagerFramework\Media` class.
 
 ### `AssetManagerFramework\Playable` Class
 
-Designed for audio and video media specifically, this extends the `AssetManagerFramework\Media` class and adds the following methods:
+Designed for audio and video media specifically, this extends the `AssetManagerFramework\Media` class and adds the following
+methods:
 
 **`set_length( string $duration )`**
 
@@ -372,7 +399,7 @@ Set the thumbnail URL for the media.
 
 **`set_bitrate( int $bitrate, string $bitrate_mode = '' )`**
 
-Sets the bitrate and optional bitrate mode.
+Sets the bit rate and optional bit rate mode.
 
 ### `AssetManagerFramework\Video` Class
 
@@ -418,4 +445,5 @@ Filters the AMF provider class during registration. This filter receives each pr
 
 **`amf/script/data: array`**
 
-Filters the data passed client side to the media library integration. By default this contains an associative array with an item called `providers` that is an array of all registered providers including their ID, name and feature support.
+Filters the data passed client side to the media library integration. By default this contains an associative array with an item
+called `providers` that is an array of all registered providers including their ID, name and feature support.

--- a/docs/dynamic-images.md
+++ b/docs/dynamic-images.md
@@ -1,44 +1,58 @@
 # Dynamic Images
 
-The Media module supports dynamic image resizing via a microservice called [Tachyon](https://github.com/humanmade/tachyon). Tachyon allows arbitrary image resizes to be done on the fly, supports lossless image compression and many file formats such as WebP for supported browsers.
+The Media module supports dynamic image resizing via a microservice called [Tachyon](https://github.com/humanmade/tachyon). Tachyon
+allows arbitrary image resizes to be done on the fly, supports lossless image compression and many file formats such as WebP for
+supported browsers.
 
-By default the Tachyon service is enabled. It can be explicitly disabled by setting the `modules.media.tachyon` configuration property to `false`, though this is highly discouraged.
+By default the Tachyon service is enabled. It can be explicitly disabled by setting the `modules.media.tachyon` configuration
+property to `false`, though this is highly discouraged.
 
-All images rendered on the front end of the website are automatically modified to use the Tachyon service URLs. Via lossless compression and automatic format conversion, image sizes can be reduced up to 70% with no degradation in quality.
+All images rendered on the front end of the website are automatically modified to use the Tachyon service URLs. Via lossless
+compression and automatic format conversion, image sizes can be reduced up to 70% with no degradation in quality.
 
 ## Responsive Images
 
-A major advantage of using Tachyon for all site images is the ability to generate more accurate `srcset` that respect a registered image size's aspect ratio rather than relying on multiple other image sizes being registered at the same aspect ratio.
+A major advantage of using Tachyon for all site images is the ability to generate more accurate `srcset` that respect a registered
+image size's aspect ratio rather than relying on multiple other image sizes being registered at the same aspect ratio.
 
-This is made possible using Tachyon's `zoom` parameter. By default all `srcset` attributes will be generated with 2x, 1.5x, 0.5x and 0.25x alternatives. The available modifiers can be configured through the `composer.json` file:
+This is made possible using Tachyon's `zoom` parameter. By default all `srcset` attributes will be generated with 2x, 1.5x, 0.5x and
+0.25x alternatives. The available modifiers can be configured through the `composer.json` file:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"media": {
-					"smart-media": {
-						"srcset-modifiers": [ 2, 1.5, 0.5, 0.25 ]
-					}
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "media": {
+                    "smart-media": {
+                        "srcset-modifiers": [
+                            2,
+                            1.5,
+                            0.5,
+                            0.25
+                        ]
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
-By using the `zoom` parameter Tachyon also applies a sliding scale of quality for output images so that larger 2x images for example don't incur a huge increase in file size. Images displayed on a web page at a smaller size than their natural size do not need to be as high quality to appear crisp.
+By using the `zoom` parameter Tachyon also applies a sliding scale of quality for output images so that larger 2x images for example
+don't incur a huge increase in file size. Images displayed on a web page at a smaller size than their natural size do not need to be
+as high quality to appear crisp.
 
 ## Custom Image Sizes
 
-Image URLs in Altis are converted to Tachyon URLs by default in all contexts (file paths remain the same). You can convert any image URL under the uploads directory to a Tachyon URL using the `tachyon_url()` function.
+Image URLs in Altis are converted to Tachyon URLs by default in all contexts (file paths remain the same). You can convert any image
+URL under the uploads directory to a Tachyon URL using the `tachyon_url()` function.
 
 ```php
 // Query parameters to append to the URL.
 $args = [
-	'lb' => '400,400',
-	'background' => 'white',
+    'lb' => '400,400',
+    'background' => 'white',
 ];
 // Generate a Tachyon URL for $image_src and $args.
 $url = tachyon_url( $image_src, $args );
@@ -46,28 +60,31 @@ $url = tachyon_url( $image_src, $args );
 
 ## Default Settings
 
-By default in Altis all Tachyon URLs for image sizes that result in a cropped image will have smart cropping applied. You can apply additional default modifications using the following filter:
+By default in Altis all Tachyon URLs for image sizes that result in a cropped image will have smart cropping applied. You can apply
+additional default modifications using the following filter:
 
 **`tachyon_pre_args: array $args [, array $downsize_args]`**
 
 - `$args` is an array of arguments used to generate the Tachyon URL query string.
 - `$downsize_args` if available provides additional context such as the requested image size name and attachment ID.
 
-## Query Args Reference
+## Query Arguments Reference
 
 The following query string arguments can be applied to any image delivered by Tachyon.
 
-| URL Arg | Type | Description |
-|---|----|---|
-|`w`|Number|Max width of the image.|
-|`h`|Number|Max height of the image.|
-|`quality`|Number, 0-100|Image quality.|
-|`resize`|String, "w,h"|A comma separated string of the target width and height in pixels. Crops the image.|
-|`crop_strategy`|String, "smart", "entropy", "attention"|There are 3 automatic cropping strategies for use with `resize`: <ul><li>`attention`: good results, ~70% slower</li><li>`entropy`: mediocre results, ~30% slower</li><li>`smart`: best results, ~50% slower</li>|
-|`gravity`|String|Alternative to `crop_strategy`. Crops are made from the center of the image by default, passing one of "north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest" or "center" will crop from that edge.|
-|`fit`|String, "w,h"|A comma separated string of the target maximum width and height. Does not crop the image.|
-|`crop`|Boolean\|String, "x,y,w,h"|Crop an image by percentages x-offset, y-offset, width and height (x,y,w,h). Percentages are used so that you don’t need to recalculate the cropping when transforming the image in other ways such as resizing it. You can crop by pixel values too by appending `px` to the values. `crop=160px,160px,788px,788px` takes a 788 by 788 pixel square starting at 160 by 160.|
-|`zoom`|Number|Zooms the image by the specified amount for high DPI displays. `zoom=2` produces an image twice the size specified in `w`, `h`, `fit` or `resize`. The quality is automatically reduced to keep file sizes roughly equivalent to the non-zoomed image unless the `quality` argument is passed.|
-|`webp`|Boolean, 1|Force WebP format.|
-|`lb`|String, "w,h"|Add letterboxing effect to images, by scaling them to width, height while maintaining the aspect ratio and filling the rest with black or `background`.|
-|`background`|String|Add background color via name (red) or hex value (%23ff0000). Don't forget to escape # as `%23`.|
+ <!-- markdownlint-disable MD033 -->
+| URL Arg         | Type                                    | Description                                                                                                                                                                                                                                                                                                                                                                  |
+|-----------------|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `w`             | Number                                  | Max width of the image.                                                                                                                                                                                                                                                                                                                                                      |
+| `h`             | Number                                  | Max height of the image.                                                                                                                                                                                                                                                                                                                                                     |
+| `quality`       | Number, 0-100                           | Image quality.                                                                                                                                                                                                                                                                                                                                                               |
+| `resize`        | String, "w,h"                           | A comma separated string of the target width and height in pixels. Crops the image.                                                                                                                                                                                                                                                                                          |
+| `crop_strategy` | String, "smart", "entropy", "attention" | There are 3 automatic cropping strategies for use with `resize`: <ul><li>`attention`: good results, ~70% slower</li><li>`entropy`: mediocre results, ~30% slower</li><li>`smart`: best results, ~50% slower</li>                                                                                                                                                             |
+| `gravity`       | String                                  | Alternative to `crop_strategy`. Crops are made from the center of the image by default, passing one of "north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest" or "center" will crop from that edge.                                                                                                                                            |
+| `fit`           | String, "w,h"                           | A comma separated string of the target maximum width and height. Does not crop the image.                                                                                                                                                                                                                                                                                    |
+| `crop`          | Boolean\|String, "x,y,w,h"              | Crop an image by percentages x-offset, y-offset, width and height (x,y,w,h). Percentages are used so that you don’t need to recalculate the cropping when transforming the image in other ways such as resizing it. You can crop by pixel values too by appending `px` to the values. `crop=160px,160px,788px,788px` takes a 788 by 788 pixel square starting at 160 by 160. |
+| `zoom`          | Number                                  | Zooms the image by the specified amount for high DPI displays. `zoom=2` produces an image twice the size specified in `w`, `h`, `fit` or `resize`. The quality is automatically reduced to keep file sizes roughly equivalent to the non-zoomed image unless the `quality` argument is passed.                                                                               |
+| `webp`          | Boolean, 1                              | Force WebP format.                                                                                                                                                                                                                                                                                                                                                           |
+| `lb`            | String, "w,h"                           | Add letterboxing effect to images, by scaling them to width, height while maintaining the aspect ratio and filling the rest with black or `background`.                                                                                                                                                                                                                      |
+| `background`    | String                                  | Add background color via name (red) or hex value (%23ff0000). Don't forget to escape # as `%23`.                                                                                                                                                                                                                                                                             |
+ <!-- markdownlint-enable MD033 -->

--- a/docs/global-media-library.md
+++ b/docs/global-media-library.md
@@ -4,35 +4,37 @@ The Global Media Library feature is off by default but can be enabled via the Al
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"media": {
-					"global-media-library": true
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "media": {
+                    "global-media-library": true
+                }
+            }
+        }
+    }
 }
 ```
 
-When browsing and selecting media all the files will be sourced from the dedicated global content site on the network. This means an image only needs to be uploaded once and it can be used anywhere.
+When browsing and selecting media all the files will be sourced from the dedicated global content site on the network. This means an
+image only needs to be uploaded once and it can be used anywhere.
 
-**Note**: You must run the `wp altis migrate` command to create the [Global Content Repository site](docs://core/global-content-repository.md) for this feature to function.
+**Note**: You must run the `wp altis migrate` command to create
+the [Global Content Repository site](docs://core/global-content-repository.md) for this feature to function.
 
 Alternatively the media library config option can be set to any WordPress site URL that has a public REST API.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"media": {
-					"global-media-library": "https://example.com"
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "media": {
+                    "global-media-library": "https://example.com"
+                }
+            }
+        }
+    }
 }
 ```
 
@@ -44,27 +46,28 @@ To do so you can add the following config:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"media": {
-					"local-media-library": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "media": {
+                    "local-media-library": false
+                }
+            }
+        }
+    }
 }
 ```
 
-Alternatively you can also use the `amf/allow_local_media` filter to conditionally control which sites can use Local Media and which cannot.
+Alternatively you can also use the `amf/allow_local_media` filter to conditionally control which sites can use Local Media and which
+cannot.
 
 ```php
 add_filter( 'amf/allow_local_media', function () : bool {
-	// Local for a custom site meta entry.
-	if ( get_site_meta( get_current_site_id(), 'allow_local_media' ) ) {
-		return true;
-	}
+    // Local for a custom site meta entry.
+    if ( get_site_meta( get_current_site_id(), 'allow_local_media' ) ) {
+        return true;
+    }
 
-	return false;
+    return false;
 } );
 ```

--- a/docs/image-recognition.md
+++ b/docs/image-recognition.md
@@ -1,16 +1,19 @@
 # Image Recognition
 
-The Media module includes support for automatic image recognition of all images uploaded to the CMS media library. Images are automatically tagged with keywords using machine learning, making all images uploaded to the CMS more discoverable.
+The Media module includes support for automatic image recognition of all images uploaded to the CMS media library. Images are
+automatically tagged with keywords using machine learning, making all images uploaded to the CMS more discoverable.
 
 This is implementation using the [AWS Rekognition](https://github.com/humanmade/aws-rekognition) plugin and service.
 
-By default automatic image recognition is enabled, but can be specifically disabled by setting the `modules.media.rekognition` setting to `false`.
+By default automatic image recognition is enabled, but can be specifically disabled by setting the `modules.media.rekognition`
+setting to `false`.
 
 ## Recognition features
 
 ### Labels
 
-Standard image label detection is enabled by default and provides basic information similar to tags on a piece of content, for example "nature", "aircraft" or "person" and can be searched against.
+Standard image label detection is enabled by default and provides basic information similar to tags on a piece of content, for
+example "nature", "aircraft" or "person" and can be searched against.
 
 This data can be accessed via the post meta key `hm_aws_rekognition_labels`.
 
@@ -22,88 +25,96 @@ This data can be accessed via the post meta key `hm_aws_rekognition_moderation`.
 
 ### Faces
 
-Face detection provides the location and size of any faces in an image, as well as an ID if associated with a collection. You can [learn more about creating a face collection using the AWS SDK here](https://docs.aws.amazon.com/rekognition/latest/dg/collections.html).
+Face detection provides the location and size of any faces in an image, as well as an ID if associated with a collection. You
+can [learn more about creating a face collection using the AWS SDK here](https://docs.aws.amazon.com/rekognition/latest/dg/collections.html).
 
 This data can be accessed via the post meta key `hm_aws_rekognition_faces`.
 
 ### Celebrities
 
-This feature returns data on celebrities recognized in an image. Any successful matches will be used to populate the default image alt text if not already set. The alt text can be updated after it has been set dynamically as well.
+This feature returns data on celebrities recognized in an image. Any successful matches will be used to populate the default image
+alt text if not already set. The alt text can be updated after it has been set dynamically as well.
 
 This data can be accessed via the post meta key `hm_aws_rekognition_celebrities`.
 
 ### Text
 
-Text content can be extracted from uploaded images using this feature. By default it is used to enhance relevancy when searching in the media library.
+Text content can be extracted from uploaded images using this feature. By default it is used to enhance relevancy when searching in
+the media library.
 
 This data can be accessed via the post meta key `hm_aws_rekognition_text`.
 
 ## Configuration
 
-The features described above can be toggled in your project's `composer.json` under the `extra.altis.modules.rekognition` property. The default configuration is shown below:
+The features described above can be toggled in your project's `composer.json` under the `extra.altis.modules.rekognition` property.
+The default configuration is shown below:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"media": {
-					"rekognition": {
-						"labels": true,
-						"moderation": false,
-						"faces": false,
-						"celebrities": false,
-						"text": false
-					}
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "media": {
+                    "rekognition": {
+                        "labels": true,
+                        "moderation": false,
+                        "faces": false,
+                        "celebrities": false,
+                        "text": false
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
 ## Hooks and filters
 
-You can build new features on top of the basic image recognition features either using the data collected by default or by hooking in.
+You can build new features on top of the basic image recognition features either using the data collected by default or by hooking
+in.
 
 ### `hm.aws.rekognition.process`
 
-Runs when an image is being processed and receives the AWS Rekognition client object, the attachment ID and the data to pass for the `Image` parameter. You can use this to do any custom processing such as searching for faces in an existing collection.
+Runs when an image is being processed and receives the AWS Rekognition client object, the attachment ID and the data to pass for
+the `Image` parameter. You can use this to do any custom processing such as searching for faces in an existing collection.
 
 ```php
 add_action( 'hm.aws.rekognition.process', function ( Aws\Rekognition\RekognitionClient $client, int $id, array $image_args ) {
-	$known_faces = $client->searchFacesByImage( [
-		'CollectionId' => 'ABCDEF123456',
-		'FaceMatchThreshold' => 0.9,
-		'Image' => $image_args,
-	] );
+    $known_faces = $client->searchFacesByImage( [
+        'CollectionId' => 'ABCDEF123456',
+        'FaceMatchThreshold' => 0.9,
+        'Image' => $image_args,
+    ] );
 
-	if ( ! empty( $known_faces['FaceMatches'] ) ) {
-		update_post_meta( $id, 'recognised_faces', $known_faces['FaceMatches'] );
-	}
+    if ( ! empty( $known_faces['FaceMatches'] ) ) {
+        update_post_meta( $id, 'recognised_faces', $known_faces['FaceMatches'] );
+    }
 }, 10, 2 );
 ```
 
-You can find the [full documentation for the `RekognitionClient` object here](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-rekognition-2016-06-27.html).
+You can find
+the [full documentation for the `RekognitionClient` object here](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-rekognition-2016-06-27.html).
 
 ### `hm.aws.rekognition.keywords`
 
-Filters the keywords stored and used to enhance media library search results. Receives the current keyword list, the data returned from built in image processing according to what features are enabled eg. labels, faces etc... and the attachment ID.
+Filters the keywords stored and used to enhance media library search results. Receives the current keyword list, the data returned
+from built in image processing according to what features are enabled e.g. labels, faces etc. and the attachment ID.
 
 This is useful for doing any post processing of the recognition results such as translation.
 
 ```php
 add_filter( 'hm.aws.rekognition.keywords', function ( array $keywords, array $data, int $id ) {
-	$translated_keywords = [];
+    $translated_keywords = [];
 
-	// This could be Google translate for example.
-	$translation_service = new TranslationService();
+    // This could be Google translate for example.
+    $translation_service = new TranslationService();
 
-	foreach ( $keywords as $keyword ) {
-		$translated_keywords[] = $translation_service->translate( $keyword, 'fr' );
-	}
+    foreach ( $keywords as $keyword ) {
+        $translated_keywords[] = $translation_service->translate( $keyword, 'fr' );
+    }
 
-	return $translated_keywords;
+    return $translated_keywords;
 }, 10, 3 );
 ```
 
@@ -111,19 +122,20 @@ add_filter( 'hm.aws.rekognition.keywords', function ( array $keywords, array $da
 
 Similar to the `hm.aws.rekognition.keywords` filter but allows you modify the generated alt text when none has been set yet.
 
-This can be good for enhancing the default alt text such as in the example below which lists detected celebrities as they appear from left to right in the image.
+This can be good for enhancing the default alt text such as in the example below which lists detected celebrities as they appear
+from left to right in the image.
 
 ```php
 add_filter( 'hm.aws.rekognition.alt_text', function ( string $new_alt_text, array $data, int $id ) {
-	if ( ! empty( $data['celebrities'] ) ) {
-		$celebrities = $data['celebrities'];
-		uasort( $celebrities, function ( $a, $b ) {
-			return $a['Face']['BoundingBox']['Left'] <=> $b['Face']['BoundingBox']['Left'];
-		} );
-		$names = wp_list_pluck( $celebrities, 'Name' );
-		return sprintf( 'From left to right: %s', implode( ', ', $names ) );
-	}
+    if ( ! empty( $data['celebrities'] ) ) {
+        $celebrities = $data['celebrities'];
+        uasort( $celebrities, function ( $a, $b ) {
+            return $a['Face']['BoundingBox']['Left'] <=> $b['Face']['BoundingBox']['Left'];
+        } );
+        $names = wp_list_pluck( $celebrities, 'Name' );
+        return sprintf( 'From left to right: %s', implode( ', ', $names ) );
+    }
 
-	return $new_alt_text;
+    return $new_alt_text;
 }, 10, 3 );
 ```

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -8,29 +8,35 @@ Altis provides some default image sizes, that you can use to render images in th
 - Post Thumbnail
 - Full
 
-They have default dimensions, but you can override these either with code or in the admin, under [Settings > Media](internal://admin/options-media.php).
+They have default dimensions, but you can override these either with code or in the admin,
+under [Settings > Media](internal://admin/options-media.php).
 
 ![Media Settings](./assets/media-settings.png)
 
-### Content Width
+## Content Width
 
-If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size defined in the _global_ rather than the size in the admin) in the media modal. This global is intended to be used as an upper limit on the width of images based on your theme's design.
+If your theme defines a content width via the `$content_width` (or `$GLOBALS['content_width]`) global, this size will _override_ the
+size defined on the Settings > Media page. This will result in the Large size appearing to be the "wrong" size (using the size
+defined in the _global_ rather than the size in the admin) in the media modal. This global is intended to be used as an upper limit
+on the width of images based on your theme's design.
 
-For example, if your theme had a content area that was 1000 pixels wide, you might set the `$content_width` global in your theme like this:
+For example, if your theme had a content area that was 1000 pixels wide, you might set the `$content_width` global in your theme
+like this:
 
 ```php
 add_action( 'after_setup_theme', function () {
-	global $content_width;
+    global $content_width;
 
-	$content_width = 1000;
+    $content_width = 1000;
 } );
 ```
 
-With this setting, in the admin, even if the Large image size on the Settings > Media page is greater than 1000, the _actual_ image size will never be larger than 1000, and this will be reflected in the media modal.
+With this setting, in the admin, even if the Large image size on the Settings > Media page is greater than 1000, the _actual_ image
+size will never be larger than 1000, and this will be reflected in the media modal.
 
 The `$content_width` variable has been a recommended part of a theme's `functions.php` file since WordPress 2.6.
 
-### Custom Image Sizes
+## Custom Image Sizes
 
 A lot of times, you'll find that you need custom image sizes for different contexts, depending on your theme's design.
 
@@ -46,33 +52,38 @@ This function accepts the following parameters:
 The custom image sizes should be declared in the callback function to the `after_setup_theme` action.
 
 Example:
+
 ```php
 add_action( 'after_setup_theme', 'theme_setup' );
 function theme_setup() {
-	// Set the image size by resizing the image while maintaining the aspect ratio:
-	add_image_size( 'constrained-thumbnail', 220, 180 ); // Image constrained to 220 pixels wide by 180 pixels tall
-	
-	// Set the image size by cropping the image (not showing part of it):
-	add_image_size( 'cropped-thumbnail', 220, 180, true ); // Exactly 220 pixels wide by 180 pixels tall
-	
-	// Set the image size by cropping the image and defining a crop position:
-	add_image_size( 'top-left-crop', 220, 220, [ 'left', 'top' ] ); // Hard crop left top
+    // Set the image size by resizing the image while maintaining the aspect ratio:
+    add_image_size( 'constrained-thumbnail', 220, 180 ); // Image constrained to 220 pixels wide by 180 pixels tall
+
+    // Set the image size by cropping the image (not showing part of it):
+    add_image_size( 'cropped-thumbnail', 220, 180, true ); // Exactly 220 pixels wide by 180 pixels tall
+
+    // Set the image size by cropping the image and defining a crop position:
+    add_image_size( 'top-left-crop', 220, 220, [ 'left', 'top' ] ); // Hard crop left top
 }
 ```
 
-Custom images sizes do not show up in the editor by default when editing image blocks. See the [Hooks and Filters section](#hooks-and-filters) below to find out how to do this.
+Custom images sizes do not show up in the editor by default when editing image blocks. See
+the [Hooks and Filters section](#hooks-and-filters) below to find out how to do this.
 
-### Cropping
+## Cropping
 
 Cropping behavior for the image size is dependent on the value of `$crop`:
+
 1. If `false` (default), images will be scaled, not cropped.
 2. If an array in the form of `[ x_crop_position, y_crop_position ]`:
     - `x_crop_position` accepts 'left' 'center', or 'right'.
     - `y_crop_position` accepts 'top', 'center', or 'bottom'.
-    Images will be cropped to the specified dimensions within the defined crop area.
-3. If `true`, images will be cropped to the specified dimensions using smart cropping by default, otherwise falling back to center cropping.
- 
-You can find more info in the [WordPress developer guide](https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/#add-custom-featured-image-sizes)
+      Images will be cropped to the specified dimensions within the defined crop area.
+3. If `true`, images will be cropped to the specified dimensions using smart cropping by default, otherwise falling back to center
+   cropping.
+
+You can find more info in
+the [WordPress developer guide](https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/#add-custom-featured-image-sizes)
 
 ## Using The Custom Sizes
 
@@ -99,26 +110,28 @@ echo ( ! empty( $img_url ) ) ? $img_url : '';
 
 This filter allows you to make your custom image sizes available for selection in the admin.
 
-Runs before rendering the list of available image sizes in the sidebar of the media edit screen. Used in conjuction with `add_image_size()` 
+Runs before rendering the list of available image sizes in the sidebar of the media edit screen. Used in conjunction
+with `add_image_size()`
 
 ```php
 add_filter( 'image_size_names_choose', function ( array $sizes ) : array {
-	$sizes['category-thumb'] = __( 'Category Thumb' );
-	return $sizes;
+    $sizes['category-thumb'] = __( 'Category Thumb' );
+    return $sizes;
 } );
 ```
 
 ![Media Editor](./assets/attachment-details.png)
 
-You can find the [full documentation for this filter here](https://developer.wordpress.org/reference/hooks/image_size_names_choose/).
+You can find
+the [full documentation for this filter here](https://developer.wordpress.org/reference/hooks/image_size_names_choose/).
 
 ## Dynamically Defined With A Size Array
 
-In cases where a specific image size might only be used once you can define the image size via an array of width and height values in pixels:
+In cases where a specific image size might only be used once you can define the image size via an array of width and height values
+in pixels:
 
 ```php
 $thumb_url = wp_get_attachment_image_src( $attachment_id, [ 900, 450 ], true );`
 ```
 
-
-**NOTE**: This method of defining dimensions currently does not support cropping.
+**Note**: This method of defining dimensions currently does not support cropping.

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -1,34 +1,39 @@
 # Lazy Loading
 
-WordPress provides lazy loading of images by default as long as `width`
-and `height` attributes are present on an `img` tag. See
-the [Lazy Loading announcement](https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/)
-for more details.
+WordPress provides lazy loading of images by default as long as `width` and `height` attributes are present on an `img` tag. See
+the [Lazy Loading announcement](https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/) for more details.
 
 ## Lazy Loading Inline Frames
 
-Inline frames are lazy-loaded by default using the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading). Only `<iframe>` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout shifting. Embedded `<iframe>` tags provided via oEmbed in content run through `the_content`, `the_excerpt` or `widget_text_content` filters will have the `loading="lazy"` attribute added by default where the web service has provided a `width` and `height` attribute.
+Inline frames are lazy-loaded by default using
+the [browser-level `loading` attribute](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading).
+Only `<iframe>` tags with both `width` and `height` attributes present will be lazy-loaded to avoid a negative impact on layout
+shifting. Embedded `<iframe>` tags provided via oEmbed in content run through `the_content`, `the_excerpt` or `widget_text_content`
+filters will have the `loading="lazy"` attribute added by default where the web service has provided a `width` and `height`
+attribute.
 
-You can customize whether and how inline frames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable lazy-loading of inline frames from post content entirely, you could use the following code:
+You can customize whether and how inline frames are lazy loaded using the `wp_lazy_loading_enabled` filter. For example, to disable
+lazy-loading of inline frames from post content entirely, you could use the following code:
 
 ```php
 add_filter( 'wp_lazy_loading_enabled', function( $default, $tag_name, $context ) {
-	if ( $tag_name === 'iframe' && $context === 'the_content'  ) {
-		return false;
-	}
+    if ( $tag_name === 'iframe' && $context === 'the_content'  ) {
+        return false;
+    }
 
-	return $default;
+    return $default;
 }, 10, 3 );
 ```
 
-You can also use the `wp_iframe_tag_add_loading_attr` filter to customize a specific `<iframe>` tag. For example, if you wanted to disable lazy-loading on inline frames from a specific provider, like YouTube, you could use the following code:
+You can also use the `wp_iframe_tag_add_loading_attr` filter to customize a specific `<iframe>` tag. For example, if you wanted to
+disable lazy-loading on inline frames from a specific provider, like YouTube, you could use the following code:
 
 ```php
 add_filter( 'wp_iframe_tag_add_loading_attr', function( $value, $iframe, $context ) {
-	if ( $context === 'the_content' && false !== strpos( $iframe, 'youtube.com' ) ) {
-		return false;
-	}
+    if ( $context === 'the_content' && false !== strpos( $iframe, 'youtube.com' ) ) {
+        return false;
+    }
 
-	return $value;
+    return $value;
 }, 10, 3 );
 ```

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,9 @@
 # Media
 
-![](./assets/banner-media.png)
+![media banner](./assets/banner-media.png)
 
-The Media module includes features and enhancements related to uploaded media. This includes [lazy loading](./lazy-loading.md), [AI powered image classification](./image-recognition.md) plus [dynamic image manipulation](./dynamic-images.md) and cropping tools.
+The Media module includes features and enhancements related to uploaded media. This
+includes [lazy loading](./lazy-loading.md), [AI powered image classification](./image-recognition.md)
+plus [dynamic image manipulation](./dynamic-images.md) and cropping tools.
 
 In addition to the above features there are low-level enhancements including SVG sanitization to mitigate XSS attacks.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,28 +2,36 @@
 
 ## Some Image URLs Are Broken With Tachyon Enabled
 
-Prior to WordPress 5.3.1 any image files uploaded with a file name like `example-300x300.jpg` were allowed and unmodified. In order to better support automatic modification of image URLs for features like responsive images the dimensions are removed.
+Prior to WordPress 5.3.1 any image files uploaded with a file name like `example-300x300.jpg` were allowed and unmodified. In order
+to better support automatic modification of image URLs for features like responsive images the dimensions are removed.
 
 In order to work properly and for performance reasons Tachyon requires all images to not have dimensions as their suffix.
 
-Altis provides a migration command to rename legacy images and make the necessary database updates. The command will rename images, regnerate thumbnails and update the attachment data by default. It is _highly_ recommended to pass the `--search-replace` flag to update your post content and post meta data too.
+Altis provides a migration command to rename legacy images and make the necessary database updates. The command will rename images,
+regenerate thumbnails and update the attachment data by default. It is _highly_ recommended to pass the `--search-replace` flag to
+update your post content and post meta data too.
 
-The database tables and columns the search & replace is performed on can be altered but default to only updating post content and post meta to keep the process as quick as it can be.
+The database tables and columns the search & replace is performed on can be altered but default to only updating post content and
+post meta to keep the process as quick as it can be.
 
-```
+```sh
 wp media rename-images [--network] [--sites-page=<int>] [--search-replace] [--tables=<tables>] [--include-columns=<columns>]
 ```
 
 Recommended usage:
 
-```
+```sh
 wp media rename-images --network --search-replace --url=<primary site hostname>
 ```
 
 - `--network` if present will run the process for all sites on the network.
-- `--sites-page` allows you to change the current page of sites. 100 sites will be processed at a time so if you have more you will need to run the command again for each page of sites.
+- `--sites-page` allows you to change the current page of sites. 100 sites will be processed at a time so if you have more you will
+  need to run the command again for each page of sites.
 - `--search-replace` if present will perform a database search and replace process for the updated image names.
-- `--tables` defaults to `wp*_posts, wp*_postmeta` and accepts a comma separated list of tables you wish to run the update on. Wildcards are supported.
-- `--include-columns` defaults to `post_content, meta_value` and accepts a comma separated list of database table columns you want to perform the updates on.
+- `--tables` defaults to `wp*_posts, wp*_postmeta` and accepts a comma separated list of tables you wish to run the update on.
+  Wildcards are supported.
+- `--include-columns` defaults to `post_content, meta_value` and accepts a comma separated list of database table columns you want
+  to perform the updates on.
 
-Note that this command will take a long time to run when updating the database as well. Additionally the more tables and columns you update the slower this command will be.
+Note that this command will take a long time to run when updating the database as well. Additionally the more tables and columns you
+update the slower this command will be.


### PR DESCRIPTION
This changes all the docs files to be formatted correctly after linting. The main changes are line length, spaces instead of tabs, and addition of alt text for images.

Resolves https://github.com/humanmade/product-dev/issues/1279