### PR TITLE
Update smart-media to 0.5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"darylldoyle/safe-svg": "2.0.3",
 		"humanmade/tachyon-plugin": "~0.11.9",
-		"humanmade/smart-media": "~0.5.5",
+		"humanmade/smart-media": "~0.5.7",
 		"humanmade/aws-rekognition": "~0.1.10",
 		"humanmade/rename-images-command": "^0.1.0",
 		"humanmade/asset-manager-framework": "^0.13.5",


### PR DESCRIPTION
Updates the smart-media package to 0.5.7. This version includes a fix for a syntax error.