### PR TITLE
Update the minimum PHP Version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.2",
 		"darylldoyle/safe-svg": "2.0.3",
 		"humanmade/tachyon-plugin": "~0.11.9",
 		"humanmade/smart-media": "~0.5.7",


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: https://github.com/humanmade/product-dev/issues/1735