### PR TITLE
Updates safe-svg to version 2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=8.2",
-		"darylldoyle/safe-svg": "2.0.3",
+		"darylldoyle/safe-svg": "2.3.3",
 		"humanmade/tachyon-plugin": "~0.11.10",
 		"humanmade/smart-media": "~0.5.11",
 		"humanmade/aws-rekognition": "~0.1.10",


### PR DESCRIPTION
This updates `darylldoyle/safe-svg`` to version 2.3.3, which includes a security fix from an upstream package.

Fixes https://github.com/humanmade/product-dev/issues/1841