### PR TITLE
[Backport v21-branch] Updates safe-svg to version 2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"darylldoyle/safe-svg": "2.0.3",
+		"darylldoyle/safe-svg": "2.3.3",
 		"humanmade/tachyon-plugin": "~0.11.9",
 		"humanmade/smart-media": "~0.5.7",
 		"humanmade/aws-rekognition": "~0.1.10",


### PR DESCRIPTION
Backport #433.