### PR TITLE
Fix PrivateMedia acceptance test for WP 7.0 "Upload Media" heading

### DIFF
--- a/tests/acceptance/PrivateMediaCest.php
+++ b/tests/acceptance/PrivateMediaCest.php
@@ -36,7 +36,8 @@ class PrivateMediaCest {
 
 		// Upload a file via the Add New Media page.
 		$I->amOnAdminPage( 'media-new.php' );
-		$I->see( 'Upload New Media' );
+		// WP 7.0 renamed this page heading from "Upload New Media" to "Upload Media".
+		$I->see( 'Upload Media' );
 		$I->attachFile( 'input[type="file"]', 'wp-logo.png' );
 		$I->wait( 3 );
 		$I->waitForElement( '.media-item', 30 );


### PR DESCRIPTION
## ⚠️ Do not merge until WP 7.0 is the CI baseline

WordPress 7.0 renames the `media-new.php` page heading from **"Upload New Media"**
to **"Upload Media"**. The `PrivateMediaCest::newUploadIsPrivate` acceptance test
asserts on that heading, so it fails against WP 7.0 and passes against WP 6.x.

This change is isolated on its own branch off `issue-162-default-private-uploads-2`
specifically so the feature branch keeps passing on the current (WP 6.x) CI. It
must only merge once CI runs on WP 7.0 — otherwise it inverts the failure.

## Change

- `tests/acceptance/PrivateMediaCest.php`: `see( 'Upload New Media' )` → `see( 'Upload Media' )`, with an explanatory comment.

## Verification (local stack on WP 7.0)

Full media Codeception suite, both suites green:

- Acceptance: **OK (4 tests, 9 assertions)**
- Integration: **OK (84 tests, 182 assertions)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)